### PR TITLE
Update all calls to take a block starting on a new line.

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -4,7 +4,7 @@
         "body": [
             "before(() => {",
             "\t$1",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before "
     },
@@ -13,7 +13,7 @@
         "body": [
             "before(function $1() {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before with Named Function"
     },
@@ -22,7 +22,7 @@
         "body": [
             "before('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before with Description"
     },
@@ -31,7 +31,7 @@
         "body": [
             "beforeEach(() => {",
             "\t$1",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before Each"
     },
@@ -40,7 +40,7 @@
         "body": [
             "beforeEach(function $1() {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before Each with Named Function"
     },
@@ -49,7 +49,7 @@
         "body": [
             "beforeEach('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Before Each with Description"
     },
@@ -58,7 +58,7 @@
         "body": [
             "after(() => {",
             "\t$1",
-			"});"
+            "});"
         ],
         "description": "Mocha::After "
     },
@@ -67,7 +67,7 @@
         "body": [
             "after(function $1() {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::After with Named Function"
     },
@@ -76,7 +76,7 @@
         "body": [
             "after('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::After with Description"
     },
@@ -85,7 +85,7 @@
         "body": [
             "afterEach(() => {",
             "\t$1",
-			"});"
+            "});"
         ],
         "description": "Mocha::After Each"
     },
@@ -94,7 +94,7 @@
         "body": [
             "afterEach(function $1() {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::After Each with Named Function"
     },
@@ -103,18 +103,18 @@
         "body": [
             "afterEach('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::After Each with Description"
     },
-	"Mocha Describe And It": {
+    "Mocha Describe And It": {
         "prefix": "describeAndIt",
         "body": [
             "describe('$1', () => {",
-			"\tit('$2', () => {",
-			"\t\t$3",
-			"\t});",
-			"});"
+            "\tit('$2', () => {",
+            "\t\t$3",
+            "\t});",
+            "});"
         ],
         "description": "Mocha::Describe with It"
     },
@@ -123,23 +123,23 @@
         "body": [
             "describe('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Describe"
     },
     "Mocha It": {
         "prefix": "it",
         "body": [
-			"it('$1', () => {",
-			"\t$2",
-			"});"
+            "it('$1', () => {",
+            "\t$2",
+            "});"
         ],
         "description": "Mocha::It"
     },
     "Mocha Suite": {
         "prefix": "suite",
         "body": [
-			"suite('$1', () => {",
+            "suite('$1', () => {",
             "\t$2",
             "});"
         ],
@@ -148,7 +148,7 @@
     "Mocha Suite Setup": {
         "prefix": "suiteSetup",
         "body": [
-			"suiteSetup(() => {",
+            "suiteSetup(() => {",
             "\t$1",
             "});"
         ],
@@ -157,7 +157,7 @@
     "Mocha Setup": {
         "prefix": "setup",
         "body": [
-			"setup(() => {",
+            "setup(() => {",
             "\t$1",
             "});"
         ],
@@ -166,7 +166,7 @@
     "Mocha Suite Teardown": {
         "prefix": "suiteTeardown",
         "body": [
-			"suiteTeardown(() => {",
+            "suiteTeardown(() => {",
             "\t$1",
             "});"
         ],
@@ -175,7 +175,7 @@
     "Mocha Teardown": {
         "prefix": "teardown",
         "body": [
-			"teardown(() => {",
+            "teardown(() => {",
             "\t$1",
             "});"
         ],
@@ -184,7 +184,7 @@
     "Mocha Test": {
         "prefix": "test",
         "body": [
-			"test('$1', () => {",
+            "test('$1', () => {",
             "\t$2",
             "});"
         ],
@@ -193,7 +193,7 @@
     "Mocha Entire Suite": {
         "prefix": "entireSuite",
         "body": [
-			"suite('$1', () => {",
+            "suite('$1', () => {",
             "",
             "\tsuiteSetup(() => { });",
             "",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -2,84 +2,108 @@
     "Mocha Before": {
         "prefix": "before",
         "body": [
-            "before(() => $1);"
+            "before(() => {",
+            "\t$1",
+			"});"
         ],
         "description": "Mocha::Before "
     },
     "Mocha Before Named Function": {
         "prefix": "beforeNamed",
         "body": [
-            "before(function $1(){ $2});"
+            "before(function $1() {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::Before with Named Function"
     },
     "Mocha Before with Description": {
         "prefix": "beforeDescription",
         "body": [
-            "before('$1', () => $2);"
+            "before('$1', () => {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::Before with Description"
     },
     "Mocha Before Each": {
         "prefix": "beforeEach",
         "body": [
-            "beforeEach(() => $1);"
+            "beforeEach(() => {",
+            "\t$1",
+			"});"
         ],
         "description": "Mocha::Before Each"
     },
     "Mocha Before Each Named Function": {
         "prefix": "beforeEachNamed",
         "body": [
-            "beforeEach(function $1(){ $2});"
+            "beforeEach(function $1() {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::Before Each with Named Function"
     },
     "Mocha Before Each with Description": {
         "prefix": "beforeEachDescription",
         "body": [
-            "beforeEach('$1', () => $2);"
+            "beforeEach('$1', () => {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::Before Each with Description"
     },
     "Mocha After": {
         "prefix": "after",
         "body": [
-            "after(() => $1);"
+            "after(() => {",
+            "\t$1",
+			"});"
         ],
         "description": "Mocha::After "
     },
     "Mocha After Named Function": {
         "prefix": "afterNamed",
         "body": [
-            "after(function $1(){ $2});"
+            "after(function $1() {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::After with Named Function"
     },
     "Mocha After with Description": {
         "prefix": "afterDescription",
         "body": [
-            "after('$1', () => $2);"
+            "after('$1', () => {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::After with Description"
     },
     "Mocha After Each": {
         "prefix": "afterEach",
         "body": [
-            "afterEach(() => $1);"
+            "afterEach(() => {",
+            "\t$1",
+			"});"
         ],
         "description": "Mocha::After Each"
     },
     "Mocha After Each Named Function": {
         "prefix": "afterEachNamed",
         "body": [
-            "afterEach(function $1(){ $2});"
+            "afterEach(function $1() {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::After Each with Named Function"
     },
     "Mocha After Each with Description": {
         "prefix": "afterEachDescription",
         "body": [
-            "afterEach('$1', () => $2);"
+            "afterEach('$1', () => {",
+            "\t$2",
+			"});"
         ],
         "description": "Mocha::After Each with Description"
     },


### PR DESCRIPTION
Hi!

Thanks for the awesome project!  I use this all day, erryday!

This is a PR for making all before/after hooks take a block function with a newline. I almost always have multiple statements in my beforeEach blocks, and almost never do one liner beforeEach/afterEach functions, and when I do, I just do:

```
beforeEach(() => {
   // My one liner here
});
```

I thought I'd make them all behave the same way, but I'm sure you have a coding style that the current way works really well for, so I won't feel offended if you reject this!

Regards,
Adam