### PR TITLE
Add normal functions as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Mocha snippets for Visual Studio Code using ES6 syntax.  The focus is to keep th
 
 Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow-functions)). If you don't want to pass arrow functions you can use the `f` prefix on every snippet:
 
-### BDDD
+### BDD
 
 - Before Function (fbefore)
     ```
@@ -207,7 +207,7 @@ Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow
     });
     ```
 
-### TDDD
+### TDD
 - Context Function (fcontext)
     ```
     context('', function () {});
@@ -215,7 +215,7 @@ Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow
 - Context and It Function (fcontextAndIt)
     ```
     context('', function () {
-    it('', function () {});
+      it('', function () {});
     });
     ```
 - It Function (fit)
@@ -245,9 +245,9 @@ Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow
 - Entire Suite Function (fentireSuite)
     ```
     suite('', function () {
-    suiteSetup(function () { });
-    test('', function () {});
-    suiteTeardown(function () { });
+      suiteSetup(function () { });
+      test('', function () {});
+      suiteTeardown(function () { });
     });
     ```
 
@@ -256,9 +256,9 @@ Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow
 - Exports Suite Function (fexportsSuite)
     ```
     suite('', function () {
-    suiteSetup(function () { });
-    test('', function () {});
-    suiteTeardown(function () { });
+      suiteSetup(function () { });
+      test('', function () {});
+      suiteTeardown(function () { });
     });
     ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mocha snippets for Visual Studio Code using ES6 syntax.  The focus is to keep th
 
 ## Included Snippet Interfaces
 
-#BDD
+### BDD
 - Before (before)
     ```
     before(() => );
@@ -88,7 +88,7 @@ Mocha snippets for Visual Studio Code using ES6 syntax.  The focus is to keep th
 
     });
     ```
-#TDD
+### TDD
 - Suite (suite)
     ```
     suite('some thing', () => {
@@ -146,7 +146,7 @@ Mocha snippets for Visual Studio Code using ES6 syntax.  The focus is to keep th
     });
     ```
 
-# Exports
+### Exports
 - Exports Suite (exportsSuite)
     ```
     exports.Foo = {
@@ -158,14 +158,117 @@ Mocha snippets for Visual Studio Code using ES6 syntax.  The focus is to keep th
     };
     ```
 
+## Arrow Functions
 
-### Other Great Tools:
+Mocha discourage passing arrow functions (more [here](https://mochajs.org/#arrow-functions)). If you don't want to pass arrow functions you can use the `f` prefix on every snippet:
+
+### BDDD
+
+- Before Function (fbefore)
+    ```
+    before(function () {});
+    ```
+- Before with Description Function (fbeforeDescription)
+    ```
+    before('', function () {});
+    ```
+- Before Each Function (fbeforeEach)
+    ```
+    beforeEach(function () {});
+    ```
+- Before Each with Description Function (fbreforeEach)
+    ```
+    beforeEach('', function () {});
+    ```
+- After Function (fafter)
+    ```
+    after(function () {});
+    ```
+- After with Description Function (fafterDescription)
+    ```
+    after('', function () {});
+    ```
+- After Each Function (fafterEach)
+    ```
+    afterEach(function () {});
+    ```
+- After Each with Description Function (fafterEach)
+    ```
+    afterEach('', function () {});
+    ```
+- Describe Function (fdescribe)
+    ```
+    describe('', function () {});
+    ```
+- Describe and It Function (fdescribeAndIt)
+    ```
+    describe('', function () {
+      it('', function () {});
+    });
+    ```
+
+### TDDD
+- Context Function (fcontext)
+    ```
+    context('', function () {});
+    ```
+- Context and It Function (fcontextAndIt)
+    ```
+    context('', function () {
+    it('', function () {});
+    });
+    ```
+- It Function (fit)
+    ```
+    it('', function () {});
+    ```
+- Suite Function (fsuite)
+    ```
+    suite('', function () {});
+    ```
+- Suite Teardow Function (fsuiteTeardown)
+    ```
+    suiteTeardown(function () {});
+    ```
+- Setup Function (fsetup)
+    ```
+    setup(function () {});
+    ```
+- Teardown Function (fteardown)
+    ```
+    teardown(function () {});
+    ```
+- Test Function (ftest)
+    ```
+    test('', function () {});
+    ```
+- Entire Suite Function (fentireSuite)
+    ```
+    suite('', function () {
+    suiteSetup(function () { });
+    test('', function () {});
+    suiteTeardown(function () { });
+    });
+    ```
+
+### Exports
+
+- Exports Suite Function (fexportsSuite)
+    ```
+    suite('', function () {
+    suiteSetup(function () { });
+    test('', function () {});
+    suiteTeardown(function () { });
+    });
+    ```
+
+## Other Great Tools:
 * [Visual Studio Code](http://code.visualstudio.com/)
 * [Mocha](https://mochajs.org/)
 * [Sinon JS](http://sinonjs.org/)
 * [Chai JS](https://chaijs.com/)
 
-### Supported languages (file extensions)
+## Supported languages (file extensions)
 * JavaScript (.js)
 * TypeScript (.ts)
 * JavaScript React (.jsx)

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -8,6 +8,15 @@
         ],
         "description": "Mocha::Before "
     },
+    "Mocha Before Function": {
+        "prefix": "fbefore",
+        "body": [
+            "before(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::Before::Function"
+    },
     "Mocha Before Named Function": {
         "prefix": "beforeNamed",
         "body": [
@@ -26,6 +35,15 @@
         ],
         "description": "Mocha::Before with Description"
     },
+    "Mocha Before with Description Function": {
+        "prefix": "fbeforeDescription",
+        "body": [
+            "before('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Before with Description::Function"
+    },
     "Mocha Before Each": {
         "prefix": "beforeEach",
         "body": [
@@ -34,6 +52,15 @@
             "});"
         ],
         "description": "Mocha::Before Each"
+    },
+    "Mocha Before Each Function": {
+        "prefix": "fbeforeEach",
+        "body": [
+            "beforeEach(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::Before Each::Function"
     },
     "Mocha Before Each Named Function": {
         "prefix": "beforeEachNamed",
@@ -53,6 +80,15 @@
         ],
         "description": "Mocha::Before Each with Description"
     },
+    "Mocha Before Each with Description Function": {
+        "prefix": "fbeforeEachDescription",
+        "body": [
+            "beforeEach('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Before Each with Description::Function"
+    },
     "Mocha After": {
         "prefix": "after",
         "body": [
@@ -60,7 +96,16 @@
             "\t$1",
             "});"
         ],
-        "description": "Mocha::After "
+        "description": "Mocha::After"
+    },
+    "Mocha After Function": {
+        "prefix": "fafter",
+        "body": [
+            "after(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::After::Function"
     },
     "Mocha After Named Function": {
         "prefix": "afterNamed",
@@ -80,6 +125,15 @@
         ],
         "description": "Mocha::After with Description"
     },
+    "Mocha After with Description Function": {
+        "prefix": "fafterDescription",
+        "body": [
+            "after('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::After with Description::Function"
+    },
     "Mocha After Each": {
         "prefix": "afterEach",
         "body": [
@@ -88,6 +142,15 @@
             "});"
         ],
         "description": "Mocha::After Each"
+    },
+    "Mocha After Each Function": {
+        "prefix": "fafterEach",
+        "body": [
+            "fafterEach(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::After Each::Function"
     },
     "Mocha After Each Named Function": {
         "prefix": "afterEachNamed",
@@ -107,6 +170,15 @@
         ],
         "description": "Mocha::After Each with Description"
     },
+    "Mocha After Each with Description Function": {
+        "prefix": "fafterEachDescription",
+        "body": [
+            "afterEach('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::After Each with Description::Function"
+    },
     "Mocha Describe And It": {
         "prefix": "describeAndIt",
         "body": [
@@ -118,6 +190,17 @@
         ],
         "description": "Mocha::Describe with It"
     },
+    "Mocha Describe And It Function": {
+        "prefix": "fdescribeAndIt",
+        "body": [
+            "describe('$1', function () {",
+            "\tit('$2', function () {",
+            "\t\t$3",
+            "\t});",
+            "});"
+        ],
+        "description": "Mocha::Describe with It::Function"
+    },
     "Mocha Describe": {
         "prefix": "describe",
         "body": [
@@ -127,25 +210,54 @@
         ],
         "description": "Mocha::Describe"
     },
-	"Mocha Context And It": {
+    "Mocha Describe Function": {
+        "prefix": "fdescribe",
+        "body": [
+            "describe('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Describe::Function"
+    },
+    "Mocha Context And It": {
         "prefix": "contextAndIt",
         "body": [
             "context('$1', () => {",
-			"\tit('$2', () => {",
-			"\t\t$3",
-			"\t});",
-			"});"
+            "\tit('$2', () => {",
+            "\t\t$3",
+            "\t});",
+            "});"
         ],
         "description": "Mocha::Context with It"
+    },
+    "Mocha Context And It Function": {
+        "prefix": "fcontextAndIt",
+        "body": [
+            "context('$1', function () {",
+            "\tit('$2', function () {",
+            "\t\t$3",
+            "\t});",
+            "});"
+        ],
+        "description": "Mocha::Context with It::Function"
     },
     "Mocha Context": {
         "prefix": "context",
         "body": [
             "context('$1', () => {",
             "\t$2",
-			"});"
+            "});"
         ],
         "description": "Mocha::Context"
+    },
+    "Mocha Context Function": {
+        "prefix": "fcontext",
+        "body": [
+            "context('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Context::Function"
     },
     "Mocha It": {
         "prefix": "it",
@@ -156,6 +268,15 @@
         ],
         "description": "Mocha::It"
     },
+    "Mocha It Function": {
+        "prefix": "fit",
+        "body": [
+            "it('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::It::Function"
+    },
     "Mocha Suite": {
         "prefix": "suite",
         "body": [
@@ -164,6 +285,15 @@
             "});"
         ],
         "description": "Mocha::Suite"
+    },
+    "Mocha Suite Function": {
+        "prefix": "fsuite",
+        "body": [
+            "suite('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Suite::Function"
     },
     "Mocha Suite Setup": {
         "prefix": "suiteSetup",
@@ -174,6 +304,15 @@
         ],
         "description": "Mocha::SuiteSetup"
     },
+    "Mocha Suite Setup Function": {
+        "prefix": "fsuiteSetup",
+        "body": [
+            "suiteSetup(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::SuiteSetup::Function"
+    },
     "Mocha Setup": {
         "prefix": "setup",
         "body": [
@@ -182,6 +321,15 @@
             "});"
         ],
         "description": "Mocha::Setup"
+    },
+    "Mocha Setup Function": {
+        "prefix": "fsetup",
+        "body": [
+            "setup(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::Setup::Function"
     },
     "Mocha Suite Teardown": {
         "prefix": "suiteTeardown",
@@ -192,6 +340,15 @@
         ],
         "description": "Mocha::SuiteTeardown"
     },
+    "Mocha Suite Teardown Function": {
+        "prefix": "fsuiteTeardown",
+        "body": [
+            "suiteTeardown(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::SuiteTeardown::Function"
+    },
     "Mocha Teardown": {
         "prefix": "teardown",
         "body": [
@@ -201,6 +358,15 @@
         ],
         "description": "Mocha::Teardown"
     },
+    "Mocha Teardown Function": {
+        "prefix": "fteardown",
+        "body": [
+            "teardown(function () {",
+            "\t$1",
+            "});"
+        ],
+        "description": "Mocha::Teardown::Function"
+    },
     "Mocha Test": {
         "prefix": "test",
         "body": [
@@ -209,6 +375,15 @@
             "});"
         ],
         "description": "Mocha::Test"
+    },
+    "Mocha Test Function": {
+        "prefix": "ftest",
+        "body": [
+            "test('$1', function () {",
+            "\t$2",
+            "});"
+        ],
+        "description": "Mocha::Test::Function"
     },
     "Mocha Entire Suite": {
         "prefix": "entireSuite",
@@ -226,6 +401,22 @@
         ],
         "description": "Mocha::EntireSuite"
     },
+    "Mocha Entire Suite Function": {
+        "prefix": "fentireSuite",
+        "body": [
+            "suite('$1', function () {",
+            "",
+            "\tsuiteSetup(function () { });",
+            "",
+            "\ttest('$2', function () {",
+            "\t\t$3",
+            "\t});",
+            "",
+            "\tsuiteTeardown(function () { });",
+            "});"
+        ],
+        "description": "Mocha::EntireSuite::Function"
+    },
     "Mocha Exports Suite": {
         "prefix": "exportsSuite",
         "body": [
@@ -238,5 +429,18 @@
             "};"
         ],
         "description": "Mocha::ExportsSuite"
+    },
+    "Mocha Exports Suite Function": {
+        "prefix": "fexportsSuite",
+        "body": [
+            "exports.$1 = {",
+            "\t'$2': {",
+            "\t\t'$3': function () {",
+            "\t\t\t$4",
+            "\t\t},",
+            "\t}",
+            "};"
+        ],
+        "description": "Mocha::ExportsSuite::Function"
     }
 }


### PR DESCRIPTION
Mocha recommends avoiding arrow functions Due to the lexical binding of
`this`. More [here](https://mochajs.org/#arrow-functions).
This PR replaces every arrow function with plain functions. Also updates
the documentation.