### PR TITLE
Rewrite some stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,12 +67,14 @@
           "description": "Add a custom glob pattern for file (**/*.spec.ts) that you want the extension to apply to."
         },
         "mocha-snippets.function-type": {
-          "type": [
-            "both",
+          "type": "string",
+          "enum":[            
             "arrow",
-            "function"
+            "function",
+            "prefixArrow",
+            "prefixFunction"
           ],
-          "default": "both",
+          "default": "function",
           "description": "Choose what type of snippets you prefer to use either 'arrow' (() =>), 'function' (function), or both"
         },
         "mocha-snippets.semicolon": {

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -1,4 +1,4 @@
-type Snippet = { body: string[], description: string, prefix: string, functionType: 'arrow' | 'function' | 'both' }
+export type Snippet = { body: string[], description: string, prefix: string, functionType: 'arrow' | 'function' }
 
 const snippets: Snippet[] = [
     {


### PR DESCRIPTION
1. Fixed the type issue on `function-type` config, which broke the snippet
2. enable user to decide what `it` means, rather than hard coded `it` and `fit`
3. Some refactorings

Spec not working yet, and seems dependencies version is also not right. I reckon it is because of some version compatibility issue