### PR TITLE
Adding snippet that combines describe, before and it

### DIFF
--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -226,6 +226,36 @@ const snippets: Snippet[] = [
     description: "Mocha::Describe with It::Function"
   },
   {
+    prefix: "describeAndBeforeAndIt",
+    functionType: 'arrow',
+    body: [
+      "describe('${1}', () => {",
+      "\tbefore('${2}', () => {",
+      "\t\t${4}",
+      "\t});",
+      "\tit('${3}', () => {",
+      "\t\t${5}",
+      "\t});",
+      "});"
+    ],
+    description: "Mocha::Describe with Before and It"
+  },
+  {
+    prefix: "fdescribeAndBeforeAndIt",
+    functionType: 'function',
+    body: [
+      "describe('${1}', function () {",
+      "\tbefore('${2}', function () {",
+      "\t\t${4}",
+      "\t});",
+      "\tit('${3}', function () {",
+      "\t\t${5}",
+      "\t});",
+      "});"
+    ],
+    description: "Mocha::Describe with Before::Function and It::Function"
+  },
+  {
     prefix: "describe",
     functionType: 'arrow',
     body: [


### PR DESCRIPTION
These changes include a follow-up on the snippet  `describeAndIt` by adding a `before` block as well. 

Typing `describeAndBeforeAndIt`  should give something like this:
```
describe('', () => {
    before(() => {

    });
    it('', () => {

    });
});
```